### PR TITLE
fix: add timeout template for OpenCerts

### DIFF
--- a/src/DefaultTemplate.stories.ts
+++ b/src/DefaultTemplate.stories.ts
@@ -1,4 +1,5 @@
-import { DefaultTemplate } from "./DefaultTemplate";
+import React from "react";
+import { DefaultTemplate, ConnectionFailureTemplate } from "./DefaultTemplate";
 
 export default {
   title: "DefaultTemplate",
@@ -23,5 +24,17 @@ export const NonEditableValue = {
         url: "http://localhost:3000",
       },
     },
+  },
+};
+
+export const ConnectionFailure = {
+  name: "Connection Failure (OpenCerts only)",
+  render: ConnectionFailureTemplate,
+  decorators: [
+    (Story: any) =>
+      React.createElement("div", { style: { padding: "4rem 0", textAlign: "center" } }, React.createElement(Story)),
+  ],
+  args: {
+    source: "http://localhost:3000",
   },
 };

--- a/src/DefaultTemplate.tsx
+++ b/src/DefaultTemplate.tsx
@@ -11,6 +11,29 @@ const container = {
 const textColor = `#333`;
 const paddingBox = `.75rem 1.25rem`;
 
+export interface ConnectionFailureProps {
+  source?: string;
+}
+
+export const ConnectionFailureTemplate: React.FunctionComponent<ConnectionFailureProps> = (props) => {
+  return (
+    <div style={{ ...container, fontFamily: "Arial", wordBreak: "break-all" }}>
+      <div style={{ backgroundColor: "#FDFDEA", borderLeft: "2px solid #8E4B10", padding: "16px 16px 16px 18px" }}>
+        <p style={{ margin: "0px", lineHeight: "21px", fontSize: "16px", color: "#8E4B10", fontWeight: "700" }}>
+          This document might be having loading issues
+        </p>
+        <p style={{ margin: "0px", lineHeight: "21px", fontSize: "14px", color: "#374151", marginTop: "6px" }}>
+          Try refreshing the page or check your internet connection. If the issue continues, please contact the issuer
+          with the information below:
+          <br />
+          <br />
+          <span style={{ fontFamily: "Courier" }}>Template URL: &quot;{props.source}&quot;</span>
+        </p>
+      </div>
+    </div>
+  );
+};
+
 export const DefaultTemplate: React.FunctionComponent<TemplateProps<any>> = (props) => {
   return (
     <div id="default-template">

--- a/src/components/frame/FrameConnector.tsx
+++ b/src/components/frame/FrameConnector.tsx
@@ -86,7 +86,8 @@ export const FrameConnector: FunctionComponent<FrameConnectorProps> = ({
     };
   }, [dispatchProxy]);
 
-  const isOpenCerts = typeof window !== "undefined" && window.location.hostname.endsWith("opencerts.io");
+  const hostname = typeof window !== "undefined" ? window.location.hostname : "";
+  const isOpenCerts = hostname === "opencerts.io" || hostname.endsWith(".opencerts.io");
   const DEFAULT_RENDERER_URL = `https://generic-templates.tradetrust.io`;
   const originalIframe = useRef<HTMLIFrameElement>(null);
   const fallbackIframe = useRef<HTMLIFrameElement>(null);

--- a/src/components/frame/FrameConnector.tsx
+++ b/src/components/frame/FrameConnector.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, FunctionComponent, useEffect, useMemo, useRef, useState } from "react";
 import { useChildFrame } from "./useFrame";
 import { HostActions, HostActionsHandler, LegacyHostActions } from "./host.actions";
+import { ConnectionFailureTemplate } from "../../DefaultTemplate";
 import {
   FrameActions,
   LegacyFrameActions,
@@ -85,6 +86,7 @@ export const FrameConnector: FunctionComponent<FrameConnectorProps> = ({
     };
   }, [dispatchProxy]);
 
+  const isOpenCerts = typeof window !== "undefined" && window.location.hostname.endsWith("opencerts.io");
   const DEFAULT_RENDERER_URL = `https://generic-templates.tradetrust.io`;
   const originalIframe = useRef<HTMLIFrameElement>(null);
   const fallbackIframe = useRef<HTMLIFrameElement>(null);
@@ -170,10 +172,14 @@ export const FrameConnector: FunctionComponent<FrameConnectorProps> = ({
     <>
       {!useFallbackSource ? (
         timeout ? (
-          <>
-            <h3>Connection timeout on renderer</h3>
-            <p>Please contact the administrator of {source}.</p>
-          </>
+          isOpenCerts ? (
+            <ConnectionFailureTemplate source={source} />
+          ) : (
+            <>
+              <h3>Connection timeout on renderer</h3>
+              <p>Please contact the administrator of {source}.</p>
+            </>
+          )
         ) : (
           <iframe
             title="Decentralised Rendered Certificate"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced connection-failure experience for opencerts.io with a styled failure notice that shows the source URL when a connection times out.
  * Added a Storybook entry to preview the connection-failure state (decorated preview with example source).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->