### PR TITLE
refactor: enhance type definitions and improve DomListener component

### DIFF
--- a/src/components/common/DomListener.tsx
+++ b/src/components/common/DomListener.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 
 // no tests because js-dom doesn't support MutationObserver
 // https://github.com/jsdom/jsdom/issues/639
@@ -24,15 +23,16 @@ export class DomListener extends Component<DomListenerProps> {
   public observer: MutationObserver;
   private readonly onResize: () => void;
   private readonly onDomChange: () => void;
+  private readonly rootRef: React.RefObject<HTMLDivElement>;
   constructor(props: DomListenerProps) {
     super(props);
     this.onResize = this.onUpdateHeight("resize").bind(this);
     this.onDomChange = this.onUpdateHeight("domChange").bind(this);
     this.observer = new MutationObserver(this.onDomChange);
+    this.rootRef = React.createRef<HTMLDivElement>();
   }
   componentDidMount(): void {
-    // eslint-disable-next-line react/no-find-dom-node
-    const rootNode = ReactDOM.findDOMNode(this);
+    const rootNode = this.rootRef.current;
     if (rootNode) {
       this.observer.observe(rootNode, { attributes: true, childList: true, subtree: true, characterData: true });
       // need an initial trigger, make it run on next tick :shrug:
@@ -51,6 +51,6 @@ export class DomListener extends Component<DomListenerProps> {
   }
 
   render(): React.ReactNode {
-    return <div>{this.props.children}</div>;
+    return <div ref={this.rootRef}>{this.props.children}</div>;
   }
 }

--- a/src/components/frame/FrameConnector.tsx
+++ b/src/components/frame/FrameConnector.tsx
@@ -59,7 +59,7 @@ export const FrameConnector: FunctionComponent<FrameConnectorProps> = ({
   onConnected,
   style,
   className = "",
-  sandbox = "allow-scripts allow-same-origin allow-modals allow-popups",
+  sandbox = "allow-scripts allow-same-origin allow-modals allow-popups allow-presentation",
   useFallbackRenderer = false,
 }) => {
   // this is used to store internally the latest templates shared in order to automatically transform

--- a/src/components/frame/FrameConnector.tsx
+++ b/src/components/frame/FrameConnector.tsx
@@ -59,7 +59,7 @@ export const FrameConnector: FunctionComponent<FrameConnectorProps> = ({
   onConnected,
   style,
   className = "",
-  sandbox = "allow-scripts allow-same-origin allow-modals allow-popups allow-presentation",
+  sandbox = "allow-scripts allow-same-origin allow-modals allow-popups",
   useFallbackRenderer = false,
 }) => {
   // this is used to store internally the latest templates shared in order to automatically transform

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 import { ComponentType } from "react";
 import { v2, WrappedDocument, OpenAttestationDocument, v3, SignedVerifiableCredential } from "@trustvc/trustvc";
 
+export type Document = SignedVerifiableCredential | OpenAttestationDocument;
+export type { OpenAttestationDocument, SignedVerifiableCredential } from '@trustvc/trustvc';
+
 export type Attachment = v2.Attachment | v3.Attachment;
 export interface Renderer {
   attachment: Attachment;
@@ -9,7 +12,7 @@ export interface Renderer {
 export interface TemplateProps<D extends OpenAttestationDocument | SignedVerifiableCredential> {
   document: D;
   wrappedDocument?: WrappedDocument<OpenAttestationDocument> | SignedVerifiableCredential;
-  handleObfuscation: (field: string) => void;
+  handleObfuscation?: (field: string) => void;
   errorType?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { ComponentType } from "react";
 import { v2, WrappedDocument, OpenAttestationDocument, v3, SignedVerifiableCredential } from "@trustvc/trustvc";
 
 export type Document = SignedVerifiableCredential | OpenAttestationDocument;
-export type { OpenAttestationDocument, SignedVerifiableCredential } from '@trustvc/trustvc';
+export type { OpenAttestationDocument, SignedVerifiableCredential } from "@trustvc/trustvc";
 
 export type Attachment = v2.Attachment | v3.Attachment;
 export interface Renderer {


### PR DESCRIPTION
* Added Document type to include SignedVerifiableCredential and OpenAttestationDocument.
* Made handleObfuscation optional in TemplateProps interface.
* Replaced ReactDOM.findDOMNode with a ref in DomListener for better React practices.
* Updated sandbox attribute in FrameConnector to include allow-presentation.

## Summary

What is the background of this pull request?

## Changes

- What are the changes made in this pull request?
- Change this and that, etc...

## Issues

What are the related issues or stories?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced iframe sandbox policy to include presentation support
  * Improved DOM node tracking for more reliable component behavior

* **Updates**
  * Expanded document type coverage to include verifiable credentials and attestation formats
  * Made obfuscation handler optional to allow more flexible document rendering and configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->