### PR TITLE
feat: add Bill of Exchange template and update dependencies

### DIFF
--- a/example/decentralized-renderer/templates/billOfExchange/index.tsx
+++ b/example/decentralized-renderer/templates/billOfExchange/index.tsx
@@ -1,0 +1,11 @@
+import { Template } from "./template";
+
+const templates = [
+  {
+    id: "bill-of-exchange-template",
+    label: "Bill of Exchange",
+    template: Template,
+  },
+];
+
+export default templates;

--- a/example/decentralized-renderer/templates/billOfExchange/template.tsx
+++ b/example/decentralized-renderer/templates/billOfExchange/template.tsx
@@ -44,6 +44,16 @@ const formatAmountInFigures = (currencyCode?: string, amountInFigures?: string):
   return [currencyCode, amount].filter(Boolean).join(" ");
 };
 
+/**
+ * Signature comes from credential data and must never be used as an arbitrary
+ * image URL (e.g. a remote tracking pixel). Only accept self-contained inline
+ * base64 image data.
+ */
+const DATA_IMAGE_URI = /^data:image\/(png|jpe?g|gif|webp|svg\+xml);base64,[A-Za-z0-9+/]+=*$/;
+
+const isValidInlineImage = (value?: string): value is string =>
+  !!value && DATA_IMAGE_URI.test(value);
+
 const extractData = (document: any): BillOfExchangeDocument => {
   if (!document || typeof document !== "object") return {};
   if (document.credentialSubject && typeof document.credentialSubject === "object") {
@@ -136,7 +146,7 @@ const SignatureImageCell = ({
         minHeight: 72,
       }}
     >
-      {signature ? (
+      {isValidInlineImage(signature) ? (
         <img
           src={signature}
           alt={`${label} image`}
@@ -258,7 +268,7 @@ export const Template: FunctionComponent<TemplateProps<any>> = ({ document }) =>
             />
           </tr>
           <tr>
-            <SignatureImageCell label="signature" signature={drawee?.signature} colSpan={2} />
+            <SignatureImageCell label="Signature" signature={drawee?.signature} colSpan={2} />
             <SignatureImageCell label="Signature" signature={drawer?.signature} colSpan={2} />
           </tr>
         </tbody>

--- a/example/decentralized-renderer/templates/billOfExchange/template.tsx
+++ b/example/decentralized-renderer/templates/billOfExchange/template.tsx
@@ -38,11 +38,13 @@ const formatBoeDate = (input?: string): string => {
 
 const formatAmountInFigures = (currencyCode?: string, amountInFigures?: string): string => {
   if (!amountInFigures && !currencyCode) return "";
-  const numericAmount = Number(amountInFigures);
-  const amount =
-    amountInFigures && Number.isFinite(numericAmount)
-      ? new Intl.NumberFormat("en-US").format(numericAmount)
-      : amountInFigures || "";
+  const amount = amountInFigures
+    ? amountInFigures.replace(
+        /^([+-]?\d+)(\.\d+)?$/,
+        (_, whole: string, fraction = "") =>
+          `${whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",")}${fraction}`,
+      )
+    : "";
   return [currencyCode, amount].filter(Boolean).join(" ");
 };
 

--- a/example/decentralized-renderer/templates/billOfExchange/template.tsx
+++ b/example/decentralized-renderer/templates/billOfExchange/template.tsx
@@ -38,10 +38,13 @@ const formatBoeDate = (input?: string): string => {
 
 const formatAmountInFigures = (currencyCode?: string, amountInFigures?: string): string => {
   if (!amountInFigures && !currencyCode) return "";
-  const amount = amountInFigures
-    ? new Intl.NumberFormat("en-US").format(Number(amountInFigures) || 0)
-    : "";
+  const numericAmount = Number(amountInFigures);
+  const amount =
+    amountInFigures && Number.isFinite(numericAmount)
+      ? new Intl.NumberFormat("en-US").format(numericAmount)
+      : amountInFigures || "";
   return [currencyCode, amount].filter(Boolean).join(" ");
+};
 };
 
 const extractData = (document: any): BillOfExchangeDocument => {

--- a/example/decentralized-renderer/templates/billOfExchange/template.tsx
+++ b/example/decentralized-renderer/templates/billOfExchange/template.tsx
@@ -1,0 +1,268 @@
+import React, { FunctionComponent, ReactNode } from "react";
+import { TemplateProps } from "../../../../src";
+
+export interface BillOfExchangeParty {
+  name?: string;
+  address?: string;
+  authorisedSignatoryName?: string;
+  signature?: string;
+}
+
+export interface BillOfExchangeDocument {
+  electronicDocumentIdentifier?: string;
+  referenceNumber?: string;
+  amountInFigures?: string;
+  amountInWords?: string;
+  currencyCode?: string;
+  blDate?: string;
+  placeOfIssue?: string;
+  dateOfIssue?: string;
+  tenor?: string;
+  payee?: string;
+  drawnUnder?: string;
+  drawnUnderDate?: string;
+  issuedBy?: string;
+  drawee?: BillOfExchangeParty;
+  drawer?: BillOfExchangeParty;
+}
+
+/** Matches classic BoE form dates e.g. "06 Jul 2022". */
+const formatBoeDate = (input?: string): string => {
+  const date = new Date(input || "");
+  if (isNaN(date.getTime())) return input || "";
+  const day = date.getUTCDate().toString().padStart(2, "0");
+  const month = date.toLocaleString("en-GB", { month: "short", timeZone: "UTC" });
+  const year = date.getUTCFullYear();
+  return `${day} ${month} ${year}`;
+};
+
+const formatAmountInFigures = (currencyCode?: string, amountInFigures?: string): string => {
+  if (!amountInFigures && !currencyCode) return "";
+  const amount = amountInFigures
+    ? new Intl.NumberFormat("en-US").format(Number(amountInFigures) || 0)
+    : "";
+  return [currencyCode, amount].filter(Boolean).join(" ");
+};
+
+const extractData = (document: any): BillOfExchangeDocument => {
+  if (!document || typeof document !== "object") return {};
+  if (document.credentialSubject && typeof document.credentialSubject === "object") {
+    return document.credentialSubject as BillOfExchangeDocument;
+  }
+  return document as BillOfExchangeDocument;
+};
+
+const cellStyle: React.CSSProperties = {
+  border: "1px solid #000",
+  padding: "8px",
+  verticalAlign: "top",
+  textAlign: "left",
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 12,
+  lineHeight: 1.25,
+  color: "#000",
+};
+
+const valueStyle: React.CSSProperties = {
+  marginTop: 4,
+  fontSize: 14,
+  color: "#000",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+};
+
+const FieldCell = ({
+  label,
+  value,
+  colSpan,
+  style,
+}: {
+  label: string;
+  value?: ReactNode;
+  colSpan?: number;
+  style?: React.CSSProperties;
+}): JSX.Element => (
+  <td colSpan={colSpan} style={{ ...cellStyle, ...style }}>
+    <div style={labelStyle}>{label}</div>
+    {value !== undefined && value !== null && value !== "" && <div style={valueStyle}>{value}</div>}
+  </td>
+);
+
+const PartySignedCell = ({
+  label,
+  party,
+  colSpan,
+}: {
+  label: string;
+  party?: BillOfExchangeParty;
+  colSpan?: number;
+}): JSX.Element => (
+  <FieldCell
+    label={label}
+    colSpan={colSpan}
+    style={{ height: 96 }}
+    value={
+      party?.name || party?.address ? (
+        <>
+          {party.name && <div style={{ fontWeight: 500 }}>{party.name}</div>}
+          {party.address && (
+            <div style={{ fontSize: 12, marginTop: 4, color: "#1f2937" }}>{party.address}</div>
+          )}
+        </>
+      ) : undefined
+    }
+  />
+);
+
+const SignatureImageCell = ({
+  label,
+  signature,
+  colSpan,
+}: {
+  label: string;
+  signature?: string;
+  colSpan?: number;
+}): JSX.Element => (
+  <td colSpan={colSpan} style={{ ...cellStyle, height: 120 }}>
+    <div style={labelStyle}>{label}</div>
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        marginTop: 8,
+        minHeight: 72,
+      }}
+    >
+      {signature ? (
+        <img
+          src={signature}
+          alt={`${label} image`}
+          style={{ maxHeight: 64, maxWidth: "100%", objectFit: "contain" }}
+        />
+      ) : null}
+    </div>
+  </td>
+);
+
+export const Template: FunctionComponent<TemplateProps<any>> = ({ document }) => {
+  const data = extractData(document);
+  const {
+    referenceNumber,
+    amountInFigures,
+    amountInWords,
+    currencyCode,
+    blDate,
+    placeOfIssue,
+    dateOfIssue,
+    tenor,
+    payee,
+    drawnUnder,
+    drawnUnderDate,
+    issuedBy,
+    drawee,
+    drawer,
+  } = data;
+
+  return (
+    <div
+      data-testid="bill-of-exchange-template"
+      style={{
+        fontFamily: "Arial, Helvetica, sans-serif",
+        color: "#000",
+        background: "#fff",
+        maxWidth: 896,
+        margin: "0 auto",
+        padding: 16,
+      }}
+    >
+      <h1
+        style={{
+          textAlign: "center",
+          fontSize: 20,
+          fontWeight: 700,
+          letterSpacing: "0.05em",
+          textTransform: "uppercase",
+          margin: "0 0 12px",
+        }}
+      >
+        Bill of Exchange
+      </h1>
+
+      <table style={{ width: "100%", borderCollapse: "collapse", tableLayout: "fixed" }}>
+        <colgroup>
+          <col style={{ width: "25%" }} />
+          <col style={{ width: "25%" }} />
+          <col style={{ width: "25%" }} />
+          <col style={{ width: "25%" }} />
+        </colgroup>
+        <tbody>
+          <tr>
+            <FieldCell label="Reference No." value={referenceNumber} colSpan={2} style={{ height: 52 }} />
+            <FieldCell
+              label="Amount in figures"
+              value={formatAmountInFigures(currencyCode, amountInFigures)}
+              colSpan={2}
+              style={{ height: 52 }}
+            />
+          </tr>
+          <tr>
+            <FieldCell
+              label="B/L Date (if applicable)"
+              value={formatBoeDate(blDate)}
+              colSpan={2}
+              style={{ height: 52 }}
+            />
+            <FieldCell label="Place of issue" value={placeOfIssue} style={{ height: 52 }} />
+            <FieldCell label="Date of issue" value={formatBoeDate(dateOfIssue)} style={{ height: 52 }} />
+          </tr>
+          <tr>
+            <FieldCell label="At" value={tenor} colSpan={4} style={{ height: 52 }} />
+          </tr>
+          <tr>
+            <FieldCell label="Pay to the order of" value={payee} colSpan={4} style={{ height: 52 }} />
+          </tr>
+          <tr>
+            <FieldCell
+              label="The sum of (amount in words)"
+              value={amountInWords}
+              colSpan={4}
+              style={{ height: 52 }}
+            />
+          </tr>
+          <tr>
+            <FieldCell label="Drawn under" value={drawnUnder} colSpan={2} style={{ height: 64 }} />
+            <FieldCell label="Dated" value={formatBoeDate(drawnUnderDate)} colSpan={2} style={{ height: 64 }} />
+          </tr>
+          <tr>
+            <FieldCell label="Issued by" value={issuedBy} colSpan={4} style={{ height: 52 }} />
+          </tr>
+          <tr>
+            <PartySignedCell label="Signed for and on behalf of Drawee" party={drawee} colSpan={2} />
+            <PartySignedCell label="Signed for and on behalf of Drawer" party={drawer} colSpan={2} />
+          </tr>
+          <tr>
+            <FieldCell
+              label="Name of authorized signatory"
+              value={drawee?.authorisedSignatoryName}
+              colSpan={2}
+              style={{ height: 44 }}
+            />
+            <FieldCell
+              label="Name of authorized signatory"
+              value={drawer?.authorisedSignatoryName}
+              colSpan={2}
+              style={{ height: 44 }}
+            />
+          </tr>
+          <tr>
+            <SignatureImageCell label="signature" signature={drawee?.signature} colSpan={2} />
+            <SignatureImageCell label="Signature" signature={drawer?.signature} colSpan={2} />
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/example/decentralized-renderer/templates/billOfExchange/template.tsx
+++ b/example/decentralized-renderer/templates/billOfExchange/template.tsx
@@ -45,7 +45,6 @@ const formatAmountInFigures = (currencyCode?: string, amountInFigures?: string):
       : amountInFigures || "";
   return [currencyCode, amount].filter(Boolean).join(" ");
 };
-};
 
 /**
  * Signature comes from credential data and must never be used as an arbitrary

--- a/example/decentralized-renderer/templates/govtechDemoCert/transcript.tsx
+++ b/example/decentralized-renderer/templates/govtechDemoCert/transcript.tsx
@@ -149,7 +149,7 @@ export class DemoTranscript extends Component<TemplateProps<any>, { editable: bo
             </div>
           </div>
 
-          {transcriptData !== [] && (
+          {transcriptData.length > 0 && (
             <div className="row mb-4" style={{ paddingLeft: "3%", paddingTop: "5%" }}>
               <div className="root cert-title">
                 <b>Transcript</b>

--- a/example/decentralized-renderer/templates/index.tsx
+++ b/example/decentralized-renderer/templates/index.tsx
@@ -6,10 +6,12 @@
 import CustomTemplate from "./customTemplate";
 import GovTechDemoCert from "./govtechDemoCert";
 import DriverLicense from "./driverLicense";
+import BillOfExchange from "./billOfExchange";
 
 export const registry = {
   CUSTOM_TEMPLATE: CustomTemplate,
   GOVTECH_DEMO: GovTechDemoCert,
   DRIVER_LICENSE: DriverLicense,
+  BILL_OF_EXCHANGE: BillOfExchange,
   NULL: [],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@peculiar/webcrypto": "^1.5.0",
-        "@trustvc/trustvc": "^2.5.2",
+        "@trustvc/trustvc": "2.16.0-beta.1",
         "crypto-browserify": "^3.12.1",
         "debug": "^4.4.0",
         "os-browserify": "^0.3.0",
@@ -88,6 +88,16 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@account-abstraction/contracts": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@account-abstraction/contracts/-/contracts-0.8.0.tgz",
+      "integrity": "sha512-8krPx/gpnoT+5xAroagVCbeA7FbUigMZWXFKKPm+oghyr29Dksssdx5sI7xGv9212i4JPaDDUGFk58dpuwVgHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@openzeppelin/contracts": "^5.1.0",
+        "@uniswap/v3-periphery": "^1.4.3"
       }
     },
     "node_modules/@actions/core": {
@@ -2842,32 +2852,42 @@
         "node": ">=18"
       }
     },
+    "node_modules/@digitalbazaar/bbs-2023-cryptosuite/node_modules/cborg": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.5.8.tgz",
+      "integrity": "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
     "node_modules/@digitalbazaar/bbs-signatures": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/bbs-signatures/-/bbs-signatures-3.0.0.tgz",
-      "integrity": "sha512-mQMCMnCWAraVSswJg1kJK/qmUrb3jMoWB9c8kOmztsWfnMZJcyYAcavuF8jgrVZ5cl/ZRNMK61ZbIvkqd6BE6g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/bbs-signatures/-/bbs-signatures-3.1.0.tgz",
+      "integrity": "sha512-wx86l/PFOaRcoLBPmzwpF9Oo4uYJrm4uq/B1rHX5OHD15NakmUINfRr8NAGDG356GeTBDGZkMsBFgNj1x0dc+g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@noble/curves": "^1.3.0"
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@digitalbazaar/bls12-381-multikey": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/bls12-381-multikey/-/bls12-381-multikey-2.1.0.tgz",
-      "integrity": "sha512-JelU85fNhvHl2/mqRdmrtrE2ZQJ0//+UwI0l/YFmvsOr6YN2GuKPzdkfXjpm7f3UvnBqz5f8QKFTb9mVa7mVVg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/bls12-381-multikey/-/bls12-381-multikey-2.2.0.tgz",
+      "integrity": "sha512-C71W5QIVSkLK24XsDWENOqihfy8ITKXqP2c+aKtx09j4vbHstwG6grn4sF9qKEQ2FOMm3KPIrL2byiIIqt61ow==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/bbs-signatures": "^3.0.0",
-        "@noble/curves": "^1.3.0",
+        "@noble/curves": "^2.2.0",
         "base58-universal": "^2.0.0",
         "base64url-universal": "^2.0.0",
-        "cborg": "^4.2.0"
+        "cborg": "^5.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@digitalbazaar/data-integrity": {
@@ -2885,46 +2905,67 @@
       }
     },
     "node_modules/@digitalbazaar/di-sd-primitives": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/di-sd-primitives/-/di-sd-primitives-3.1.0.tgz",
-      "integrity": "sha512-qi8H5yz4R6UmNWC6t99MSxFexniWZHME39Q77ev03afkgLMRMQSVwNGybrgeIK1VOKn0uF4YQj8quhkNlg5baQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/di-sd-primitives/-/di-sd-primitives-3.3.0.tgz",
+      "integrity": "sha512-ljbopcxLts2ALg6ce1EG3AjIlXOC77EHmkqvghtyZBNl3XwOZueBQJmTDD6XvRQq930n6kfCtvt4JUWOrg5CrQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "base64url-universal": "^2.0.0",
-        "jsonld": "^8.3.2",
+        "jsonld": "^9.0.0",
         "klona": "^2.0.6",
-        "rdf-canonize": "^4.0.1",
-        "uuid": "^10.0.0"
+        "rdf-canonize": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/@digitalbazaar/http-client": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.3.0.tgz",
+      "integrity": "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ky": "^1.14.2",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/jsonld": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
+      "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^4.2.0",
+        "canonicalize": "^2.1.0",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/jsonld": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.3.3.tgz",
-      "integrity": "sha512-9YcilrF+dLfg9NTEof/mJLMtbdX1RJ8dbWtJgE00cMOIohb1lIyJl710vFiTaiHTl6ZYODJuBd32xFvUhmv3kg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@digitalbazaar/http-client": "^3.4.1",
-        "canonicalize": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "rdf-canonize": "^3.4.0"
-      },
+    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/jsonld/node_modules/rdf-canonize": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
-      "integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "setimmediate": "^1.0.5"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=12"
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
     "node_modules/@digitalbazaar/di-sd-primitives/node_modules/lru-cache": {
@@ -2940,9 +2981,9 @@
       }
     },
     "node_modules/@digitalbazaar/di-sd-primitives/node_modules/rdf-canonize": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-4.0.1.tgz",
-      "integrity": "sha512-B5ynHt4sasbUafzrvYI2GFARgeFcD8Sx9yXPbg7gEyT2EH76rlCv84kyO6tnxzVbxUN/uJDbK1S/MXh+DsnuTA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
+      "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "setimmediate": "^1.0.5"
@@ -2951,17 +2992,13 @@
         "node": ">=18"
       }
     },
-    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@digitalbazaar/di-sd-primitives/node_modules/yallist": {
@@ -2983,6 +3020,108 @@
         "node": ">=18"
       }
     },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/-/ecdsa-rdfc-2019-cryptosuite-1.3.0.tgz",
+      "integrity": "sha512-Rhg++GnGWHJ29QyWTFW0tRqd/uGLADIsLVEq10zEIAY7D9ScoSLtyYzwZ/zBueBTXHXrtDUEL5SfrSvcKTLFyg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@digitalbazaar/ecdsa-multikey": "^1.6.0",
+        "jsonld": "^9.0.0",
+        "rdf-canonize": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/node_modules/@digitalbazaar/http-client": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.3.0.tgz",
+      "integrity": "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ky": "^1.14.2",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/node_modules/jsonld": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
+      "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^4.2.0",
+        "canonicalize": "^2.1.0",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/node_modules/rdf-canonize": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
+      "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-rdfc-2019-cryptosuite/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/@digitalbazaar/ecdsa-sd-2023-cryptosuite": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/ecdsa-sd-2023-cryptosuite/-/ecdsa-sd-2023-cryptosuite-3.4.1.tgz",
@@ -2998,6 +3137,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-sd-2023-cryptosuite/node_modules/cborg": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.5.8.tgz",
+      "integrity": "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "cborg": "lib/bin.js"
       }
     },
     "node_modules/@digitalbazaar/http-client": {
@@ -5908,6 +6056,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@mattrglobal/jsonld-signatures-bbs/node_modules/node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/@mattrglobal/jsonld-signatures-bbs/node_modules/rdf-canonize": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-2.0.1.tgz",
@@ -5983,14 +6140,11 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5998,13 +6152,28 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
       "engines": {
-        "node": "^14.21.3 || >=16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -6572,6 +6741,12 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.6.1.tgz",
+      "integrity": "sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==",
+      "license": "MIT"
+    },
     "node_modules/@peculiar/asn1-cms": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.0.tgz",
@@ -6839,6 +7014,81 @@
       "os": [
         "linux"
       ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -8808,24 +9058,15 @@
       }
     },
     "node_modules/@tradetrust-tt/dnsprove": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.18.0.tgz",
-      "integrity": "sha512-UgcwV17hZSSBW5oDb+DUtXle5XdBRWXURSASkr207PYjCxZOhZV88KHJi3PB45UgtUCbtvrJK7czSsgDNnpRtg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.21.0.tgz",
+      "integrity": "sha512-acxJGS07WLfLDli1E4uvT5IbPcmh9vzVelgEdhxzi2KE50r3k/vvkwUQl1ctgkw152cIxnqR20cch8x3HLLvcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.7.2",
         "debug": "^4.3.1",
         "runtypes": "^6.3.0"
       },
-      "engines": {
-        "node": ">=18.x"
-      }
-    },
-    "node_modules/@tradetrust-tt/document-store": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/document-store/-/document-store-4.1.1.tgz",
-      "integrity": "sha512-+gIR+icfbJOHVNXTc6D1Fo4jdwGRboZqUek/YN+ThXIaLaUP1dvD85tnEz63Nu4LfiDcjYld0aVXOfKsnCJ+yw==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.x"
       }
@@ -8877,13 +9118,19 @@
     },
     "node_modules/@tradetrust-tt/token-registry-v5": {
       "name": "@tradetrust-tt/token-registry",
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/token-registry/-/token-registry-5.5.1.tgz",
-      "integrity": "sha512-yxOdjRLSI0fPptFbicYpnb/fn4Ngbi/LuGDCQKL0vb7PLCvhT8DLpiAFbFs0cc+QAb439lnZjhPg+UbWQHufRA==",
+      "version": "5.6.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/token-registry/-/token-registry-5.6.0-beta.1.tgz",
+      "integrity": "sha512-EtxZw/WnvGQMb/MB243eHy4ejSTN8bkV7I7Y9f19xk9v/mOojFL74C/tD1zjsZUUjiQi9rzLRYlzSUNbZBN2gg==",
       "license": "Apache-2.0",
       "dependencies": {
         "ethers": "^6.13.4"
       }
+    },
+    "node_modules/@tradetrust-tt/token-registry-v5/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@tradetrust-tt/token-registry-v5/node_modules/@noble/curves": {
       "version": "1.2.0",
@@ -8925,9 +9172,9 @@
       "license": "MIT"
     },
     "node_modules/@tradetrust-tt/token-registry-v5/node_modules/ethers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+      "integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
       "funding": [
         {
           "type": "individual",
@@ -8940,13 +9187,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
+        "@adraffy/ens-normalize": "1.11.1",
         "@noble/curves": "1.2.0",
         "@noble/hashes": "1.3.2",
         "@types/node": "22.7.5",
         "aes-js": "4.0.0-beta.5",
         "tslib": "2.7.0",
-        "ws": "8.17.1"
+        "ws": "8.21.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -8965,9 +9212,9 @@
       "license": "MIT"
     },
     "node_modules/@tradetrust-tt/token-registry-v5/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -8984,6 +9231,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@tradetrust-tt/token-registry/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@tradetrust-tt/token-registry/node_modules/@noble/curves": {
       "version": "1.2.0",
@@ -9025,9 +9278,9 @@
       "license": "MIT"
     },
     "node_modules/@tradetrust-tt/token-registry/node_modules/ethers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+      "integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
       "funding": [
         {
           "type": "individual",
@@ -9040,13 +9293,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
+        "@adraffy/ens-normalize": "1.11.1",
         "@noble/curves": "1.2.0",
         "@noble/hashes": "1.3.2",
         "@types/node": "22.7.5",
         "aes-js": "4.0.0-beta.5",
         "tslib": "2.7.0",
-        "ws": "8.17.1"
+        "ws": "8.21.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9065,9 +9318,9 @@
       "license": "MIT"
     },
     "node_modules/@tradetrust-tt/token-registry/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9086,9 +9339,9 @@
       }
     },
     "node_modules/@tradetrust-tt/tradetrust": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tradetrust/-/tradetrust-6.10.2.tgz",
-      "integrity": "sha512-4zj4zlsrrQiUJQxvl4N8Pa4cLHtFtFIs0lMg6daP/gRJXIn1QWD0Kl4mQ5FsjuopeM7JOBX/xok22SmElEtT5w==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tradetrust/-/tradetrust-6.10.3.tgz",
+      "integrity": "sha512-2A/o6GguA31V7GnOfvhG1zANuxKdlBS5+k6jvAMeh/VotZEDvoOOA+mTArt5Fv+BKHhpgh7J8dS0DUohfVAiqg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9180,6 +9433,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9229,6 +9483,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/@tradetrust-tt/tradetrust/node_modules/node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/@tradetrust-tt/tradetrust/node_modules/rdf-canonize": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-2.0.1.tgz",
@@ -9263,16 +9526,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/@tradetrust-tt/tt-verify": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tt-verify/-/tt-verify-9.6.2.tgz",
-      "integrity": "sha512-G6XB/fhzIDAc+p07/cDCVCNYgKxx9x5e2HwOORPS8kMkimoB4FXNoWlV8GMXcbzjIjU4frI2KEL54y8TA8+Wpw==",
+    "node_modules/@tradetrust-tt/tradetrust/node_modules/web-did-resolver": {
+      "version": "2.0.32",
+      "resolved": "https://registry.npmjs.org/web-did-resolver/-/web-did-resolver-2.0.32.tgz",
+      "integrity": "sha512-L91/ApTmDjgzS0UDstTKn3kN/1hlQBnVcUN8K29e3xhVBpPktHYC6uvVAQ8ohbIg9D6wrrbaBQvfRArDxgJG2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tradetrust-tt/dnsprove": "^2.18.0",
-        "@tradetrust-tt/document-store": "^4.1.1",
+        "cross-fetch": "^4.1.0",
+        "did-resolver": "^4.1.0"
+      }
+    },
+    "node_modules/@tradetrust-tt/tt-verify": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tt-verify/-/tt-verify-9.7.5.tgz",
+      "integrity": "sha512-LoVrJLiWB9ZnMHoe7IGBAc4edK2upKYsfCRgo9T7VNLo3XiBM4cIr25RQ5e1AQ58m+3gKWRnpP9ZKj0qqN+xFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tradetrust-tt/dnsprove": "^2.21.0",
         "@tradetrust-tt/token-registry": "^5.5.0",
-        "@tradetrust-tt/tradetrust": "^6.10.1",
+        "@tradetrust-tt/tradetrust": "^6.10.3",
+        "@trustvc/document-store": "^1.0.3",
         "axios": "^1.7.2",
         "debug": "^4.3.1",
         "did-resolver": "^3.1.0",
@@ -9280,37 +9553,58 @@
         "ethr-did-resolver": "^4.3.3",
         "node-cache": "^5.1.2",
         "runtypes": "^6.3.0",
-        "web-did-resolver": "^2.0.4"
+        "web-did-resolver": "2.0.4"
       },
       "engines": {
         "node": ">=18.x"
       },
       "peerDependencies": {
-        "ethers": "^5.7.2"
+        "ethers": "^5.8.0"
+      }
+    },
+    "node_modules/@trustvc/document-store": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@trustvc/document-store/-/document-store-1.0.3.tgz",
+      "integrity": "sha512-YIECQwcoreIfyTbol1/5u9CGK6mbg0Q0bSN2/Ks388zLus1IXELWK5EHYuyrFPbb9d8ajsvz7m+ySsMIY9574w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@trustvc/eip7702": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@trustvc/eip7702/-/eip7702-1.0.0-beta.1.tgz",
+      "integrity": "sha512-cOGuZVLHd0+Uu7rZ/Dp2iF1VuNq+L+pWWGe+tPD/u74rSvCAzIc17dIk5HOwRBiC5awh1rXG46vLG8IRc5O01Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@account-abstraction/contracts": "^0.8.0",
+        "@openzeppelin/contracts": "^5.6.1"
       }
     },
     "node_modules/@trustvc/trustvc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@trustvc/trustvc/-/trustvc-2.5.2.tgz",
-      "integrity": "sha512-bO5BaXBLc6IcZKEKmpn6rb4azl0utqAjyL4/vKslSoLmO8UvOpydlWXMvxRaLFbHIYWtEiPDjqTMnGgm3OUVuw==",
+      "version": "2.16.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@trustvc/trustvc/-/trustvc-2.16.0-beta.1.tgz",
+      "integrity": "sha512-sXklxfioSrIV+ZyuYsyPy+WMbgOPcRweJTd2Tklg8ZdF/tQlb2yVHDTPLycSNI3YOilpRhKn9p0Y2hSJxTuRRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tradetrust-tt/dnsprove": "^2.18.0",
         "@tradetrust-tt/ethers-aws-kms-signer": "^2.1.4",
         "@tradetrust-tt/token-registry-v4": "npm:@tradetrust-tt/token-registry@^4.16.0",
-        "@tradetrust-tt/token-registry-v5": "npm:@tradetrust-tt/token-registry@^5.5.0",
-        "@tradetrust-tt/tradetrust": "^6.10.2",
-        "@tradetrust-tt/tt-verify": "^9.6.0",
-        "@trustvc/w3c": "^2.0.0",
-        "@trustvc/w3c-context": "^2.0.0",
-        "@trustvc/w3c-credential-status": "^2.0.0",
-        "@trustvc/w3c-issuer": "^2.0.0",
-        "@trustvc/w3c-vc": "^2.0.0",
+        "@tradetrust-tt/token-registry-v5": "npm:@tradetrust-tt/token-registry@^5.6.0-beta.1",
+        "@tradetrust-tt/tradetrust": "^6.10.3",
+        "@tradetrust-tt/tt-verify": "^9.7.5",
+        "@trustvc/document-store": "^1.0.3",
+        "@trustvc/eip7702": "^1.0.0-beta.1",
+        "@trustvc/w3c": "^2.4.1",
+        "@trustvc/w3c-context": "^2.4.0",
+        "@trustvc/w3c-credential-status": "^2.4.0",
+        "@trustvc/w3c-issuer": "^2.3.0",
+        "@trustvc/w3c-vc": "^2.4.1",
         "ethers": "^5.8.0",
         "ethersV6": "npm:ethers@^6.14.4",
         "js-sha3": "^0.9.3",
         "node-fetch": "^2.7.0",
-        "ts-chacha20": "^1.2.0"
+        "node-forge": "^1.3.3",
+        "permissionless": "^0.3.6",
+        "ts-chacha20": "^1.2.0",
+        "viem": "^2.53.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -9323,24 +9617,24 @@
       }
     },
     "node_modules/@trustvc/w3c": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@trustvc/w3c/-/w3c-2.0.2.tgz",
-      "integrity": "sha512-xWgyhdVjw1mR0GdLjzeoH1s4jseaEJpmJ2ndM0Xcn0zCzqeUql2C1ijnb0Sb/76R7XLUuc0hgAo1CzLp27lQKw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@trustvc/w3c/-/w3c-2.4.1.tgz",
+      "integrity": "sha512-yCyztSAbialRn9VYvXrHUE4v13q4g/BHUN4XUctzF5lrN3WsHKSgUpFUflocLdp1h5fxvJTbqyVoMSh5SDLwQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@trustvc/w3c-context": "^2.0.2",
-        "@trustvc/w3c-credential-status": "^2.0.2",
-        "@trustvc/w3c-issuer": "^2.0.2",
-        "@trustvc/w3c-vc": "^2.0.2"
+        "@trustvc/w3c-context": "^2.4.0",
+        "@trustvc/w3c-credential-status": "^2.4.0",
+        "@trustvc/w3c-issuer": "^2.3.0",
+        "@trustvc/w3c-vc": "^2.4.1"
       },
       "engines": {
         "node": ">=18.x"
       }
     },
     "node_modules/@trustvc/w3c-context": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@trustvc/w3c-context/-/w3c-context-2.0.2.tgz",
-      "integrity": "sha512-2DM73n1z2FXML9/suGHea6BcJqs7GKiJsvpozRf6lE9d3ZyFRmCd6H84f7Z7zGvacuLXMRnPX2A9DKE0ETs8HA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@trustvc/w3c-context/-/w3c-context-2.4.0.tgz",
+      "integrity": "sha512-OCRfqZfTyEZ2Lpd5RPBl36DwvaKv3qV1PgZOEA9hrnEtHMWxwS5iSdv+xFYK8pZIoeheFZKymfgcB5LL7UBQRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "did-resolver": "^4.1.0",
@@ -9357,13 +9651,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@trustvc/w3c-credential-status": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@trustvc/w3c-credential-status/-/w3c-credential-status-2.0.2.tgz",
-      "integrity": "sha512-8f5sHoDAT8YqLlHm82t/wh1HrZdmR3PgRGfDcgbKWrJtA+X2769kk6qVXCNP6tq1Ghyqe8v/HLortrXp9JSdGw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@trustvc/w3c-credential-status/-/w3c-credential-status-2.4.0.tgz",
+      "integrity": "sha512-fiMGtfOmq1x9e+vd89ZKqguYtmW2w2k2hxINkno+mDNHdt5CV8tfTH5EbL1fY0oPiuXM5SK+dV6iSBTIWGPFog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@trustvc/w3c-context": "^2.0.2",
-        "@trustvc/w3c-issuer": "^2.0.2",
+        "@trustvc/w3c-context": "^2.4.0",
+        "@trustvc/w3c-issuer": "^2.3.0",
         "base64url-universal": "^2.0.0",
         "pako": "^2.1.0"
       },
@@ -9372,9 +9666,9 @@
       }
     },
     "node_modules/@trustvc/w3c-issuer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@trustvc/w3c-issuer/-/w3c-issuer-2.0.2.tgz",
-      "integrity": "sha512-NDtEcGV7ryuWHbaX3hwlz2cN/hhDWHzA+D2AF56I7teNfev+X62pro+HrXYAa3EclPET7BI+fYmLgh61/DAl7w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@trustvc/w3c-issuer/-/w3c-issuer-2.3.0.tgz",
+      "integrity": "sha512-J/Rlae2s/ihkF0q6OmBofmzdRjDI98ED9lRFIB6Uh2WaEl8eZP7+FoStip+t1Piy6ZbO/6MwaS0QCw/6N6viMA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@digitalbazaar/bls12-381-multikey": "^2.1.0",
@@ -9395,20 +9689,31 @@
       "integrity": "sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==",
       "license": "Apache-2.0"
     },
+    "node_modules/@trustvc/w3c-issuer/node_modules/web-did-resolver": {
+      "version": "2.0.32",
+      "resolved": "https://registry.npmjs.org/web-did-resolver/-/web-did-resolver-2.0.32.tgz",
+      "integrity": "sha512-L91/ApTmDjgzS0UDstTKn3kN/1hlQBnVcUN8K29e3xhVBpPktHYC6uvVAQ8ohbIg9D6wrrbaBQvfRArDxgJG2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-fetch": "^4.1.0",
+        "did-resolver": "^4.1.0"
+      }
+    },
     "node_modules/@trustvc/w3c-vc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@trustvc/w3c-vc/-/w3c-vc-2.0.2.tgz",
-      "integrity": "sha512-3A488DgukqrKXDSNdtZE02tOfj6V9C6uRJAEKEnMiaUevxNzFO9TFpqXkeOdxNhg9yHEH7m68b6SqfwU/tbVXQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@trustvc/w3c-vc/-/w3c-vc-2.4.1.tgz",
+      "integrity": "sha512-f/pqBu70epEYVmtWvKvlhCd2F5QkV885rCcbfa9KZq9xYbOzeBueIF7P3gSdv3ILAiMCQTxvpL7hd8I8hj+M1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@digitalbazaar/bbs-2023-cryptosuite": "^2.0.1",
         "@digitalbazaar/bls12-381-multikey": "^2.1.0",
         "@digitalbazaar/data-integrity": "^2.5.0",
         "@digitalbazaar/ecdsa-multikey": "^1.8.0",
+        "@digitalbazaar/ecdsa-rdfc-2019-cryptosuite": "^1.3.0",
         "@digitalbazaar/ecdsa-sd-2023-cryptosuite": "^3.4.1",
         "@mattrglobal/jsonld-signatures-bbs": "^1.2.0",
-        "@trustvc/w3c-credential-status": "^2.0.2",
-        "@trustvc/w3c-issuer": "^2.0.2",
+        "@trustvc/w3c-credential-status": "^2.4.0",
+        "@trustvc/w3c-issuer": "^2.3.0",
         "base64url-universal": "^2.0.0",
         "cbor": "^9.0.2",
         "did-resolver": "^4.1.0",
@@ -9434,6 +9739,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -10240,6 +10546,55 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@uniswap/lib": {
+      "version": "4.0.1-alpha",
+      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz",
+      "integrity": "sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==",
+      "license": "GPL-3.0-or-later",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v2-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.1.tgz",
+      "integrity": "sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==",
+      "license": "GPL-3.0-or-later",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.1.tgz",
+      "integrity": "sha512-7pVk4hEm00j9tc71Y9+ssYpO6ytkeI0y7WE9P6UcmNzhxPePwyAxImuhVsTqWK9YFvzgtvzJHi64pBl4jUzKMQ==",
+      "license": "BUSL-1.1",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-periphery": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-periphery/-/v3-periphery-1.4.4.tgz",
+      "integrity": "sha512-S4+m+wh8HbWSO3DKk4LwUCPZJTpCugIsHrWR86m/OrUyvSqGDTXKFfc2sMuGXCZrD1ZqO3rhQsKgdWg3Hbb2Kw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@openzeppelin/contracts": "3.4.2-solc-0.7",
+        "@uniswap/lib": "^4.0.1-alpha",
+        "@uniswap/v2-core": "^1.0.1",
+        "@uniswap/v3-core": "^1.0.0",
+        "base64-sol": "1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-periphery/node_modules/@openzeppelin/contracts": {
+      "version": "3.4.2-solc-0.7",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz",
+      "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==",
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
@@ -10562,6 +10917,27 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -11554,6 +11930,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/base64-sol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-sol/-/base64-sol-1.0.1.tgz",
+      "integrity": "sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg==",
+      "license": "MIT"
+    },
     "node_modules/base64url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
@@ -11646,6 +12028,18 @@
       "license": "ISC",
       "dependencies": {
         "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/bn.js": {
@@ -12122,9 +12516,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.5.8.tgz",
-      "integrity": "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.11.tgz",
+      "integrity": "sha512-oc6Pzg/gkTobxHZNgMmny+G99dOeBMbAmnGHcZWMKtolxZBIVwfi0Pj0khxEtNU8HMFdbT5sK0HmtgecDUPP0A==",
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -13219,6 +13613,15 @@
       },
       "engines": {
         "node": ">=8.3.0"
+      }
+    },
+    "node_modules/crypto-ld/node_modules/node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/crypto-random-string": {
@@ -16801,9 +17204,9 @@
       }
     },
     "node_modules/har-validator/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -18290,6 +18693,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -19402,9 +19820,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.2.tgz",
+      "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-sha3": {
@@ -19641,6 +20059,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonld-signatures-v7/node_modules/node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/jsonld-signatures-v7/node_modules/rdf-canonize": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-2.0.1.tgz",
@@ -19749,9 +20176,9 @@
       }
     },
     "node_modules/jsonld-signatures/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -21865,9 +22292,9 @@
       }
     },
     "node_modules/neon-cli/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -22003,12 +22430,12 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp-build": {
@@ -24602,6 +25029,75 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ox": {
+      "version": "0.14.33",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+      "integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/p-each-series": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -24772,9 +25268,19 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "(MIT AND Zlib)"
     },
     "node_modules/param-case": {
@@ -25096,6 +25602,21 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "license": "MIT"
+    },
+    "node_modules/permissionless": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/permissionless/-/permissionless-0.3.7.tgz",
+      "integrity": "sha512-r1UGWkVMqFzzJ0UcKEVHh6XvOm7+SfTvy7AoGA7ZlxpE96XR+zbtb+rRAA3DOQuq6/ifov5NvUyt1xf4zxbR0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ox": "^0.11.3",
+        "viem": "^2.44.4"
+      },
+      "peerDependenciesMeta": {
+        "ox": {
+          "optional": true
+        }
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -26483,9 +27004,9 @@
       }
     },
     "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
+      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
@@ -26508,7 +27029,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
@@ -30288,9 +30809,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.26",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
-      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -30474,6 +30995,84 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/viem": {
+      "version": "2.55.10",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.10.tgz",
+      "integrity": "sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.33",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -30543,20 +31142,23 @@
       }
     },
     "node_modules/web-did-resolver": {
-      "version": "2.0.32",
-      "resolved": "https://registry.npmjs.org/web-did-resolver/-/web-did-resolver-2.0.32.tgz",
-      "integrity": "sha512-L91/ApTmDjgzS0UDstTKn3kN/1hlQBnVcUN8K29e3xhVBpPktHYC6uvVAQ8ohbIg9D6wrrbaBQvfRArDxgJG2g==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/web-did-resolver/-/web-did-resolver-2.0.4.tgz",
+      "integrity": "sha512-PORpoA4P0I3m0cLJX2IIDZ0gMKgC1PjS8DuDeg9/JCdIlFiXrZCyTG1hxvw4a4vhDKr0sZKSZL1pQDXTgqLm8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "cross-fetch": "^4.1.0",
-        "did-resolver": "^4.1.0"
+        "cross-fetch": "^3.1.2",
+        "did-resolver": "^3.1.0"
       }
     },
-    "node_modules/web-did-resolver/node_modules/did-resolver": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-4.1.0.tgz",
-      "integrity": "sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==",
-      "license": "Apache-2.0"
+    "node_modules/web-did-resolver/node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@peculiar/webcrypto": "^1.5.0",
-    "@trustvc/trustvc": "^2.5.2",
+    "@trustvc/trustvc": "2.16.0-beta.1",
     "crypto-browserify": "^3.12.1",
     "debug": "^4.4.0",
     "os-browserify": "^0.3.0",

--- a/src/utils.test.tsx
+++ b/src/utils.test.tsx
@@ -4,6 +4,8 @@ import { fullAttachmentRenderer } from "./components/renderer/FullAttachmentRend
 import { noAttachmentRenderer } from "./components/renderer/NoAttachmentRenderer";
 import { TemplateRegistry } from "./types";
 import { documentTemplates, repeat } from "./utils";
+import { registry } from "../example/decentralized-renderer/templates";
+import { Template as BillOfExchangeTemplate } from "../example/decentralized-renderer/templates/billOfExchange/template";
 
 describe("repeat", () => {
   it("should not call callback when times is 0", () => {
@@ -200,15 +202,13 @@ describe("documentTemplates", () => {
         proofValue: "uTEST",
       },
     } as unknown as SignedVerifiableCredential;
-    const BillOfExchange: React.FunctionComponent = () => <div>BoE</div>;
-    const templateRegistry: TemplateRegistry<any> = {
-      BILL_OF_EXCHANGE: [{ id: "bill-of-exchange-template", label: "Bill of Exchange", template: BillOfExchange }],
-    };
-    expect(documentTemplates(document, templateRegistry, noAttachmentRenderer)).toStrictEqual([
+    expect(
+      documentTemplates(document, registry as unknown as TemplateRegistry<any>, noAttachmentRenderer),
+    ).toStrictEqual([
       {
         id: "bill-of-exchange-template",
         label: "Bill of Exchange",
-        template: BillOfExchange,
+        template: BillOfExchangeTemplate,
         type: "custom-template",
       },
     ]);

--- a/src/utils.test.tsx
+++ b/src/utils.test.tsx
@@ -174,4 +174,43 @@ describe("documentTemplates", () => {
       }),
     ]);
   });
+
+  it("should resolve BILL_OF_EXCHANGE from a modern W3C DataIntegrityProof VC", () => {
+    const document = {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://w3id.org/security/data-integrity/v2",
+        "https://trustvc.io/context/render-method-context-v2.json",
+      ],
+      type: ["VerifiableCredential"],
+      issuer: "did:web:example.com",
+      renderMethod: [
+        {
+          id: "http://localhost:9000",
+          type: "EMBEDDED_RENDERER",
+          templateName: "BILL_OF_EXCHANGE",
+        },
+      ],
+      credentialSubject: { referenceNumber: "BOE-1" },
+      proof: {
+        type: "DataIntegrityProof",
+        cryptosuite: "ecdsa-sd-2023",
+        proofPurpose: "assertionMethod",
+        verificationMethod: "did:web:example.com#keys-1",
+        proofValue: "uTEST",
+      },
+    } as unknown as SignedVerifiableCredential;
+    const BillOfExchange: React.FunctionComponent = () => <div>BoE</div>;
+    const templateRegistry: TemplateRegistry<any> = {
+      BILL_OF_EXCHANGE: [{ id: "bill-of-exchange-template", label: "Bill of Exchange", template: BillOfExchange }],
+    };
+    expect(documentTemplates(document, templateRegistry, noAttachmentRenderer)).toStrictEqual([
+      {
+        id: "bill-of-exchange-template",
+        label: "Bill of Exchange",
+        template: BillOfExchange,
+        type: "custom-template",
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
* Introduced a new Bill of Exchange template in the decentralized renderer.
* Updated the @trustvc/trustvc package to version 2.16.0-beta.1.
* Added new dependencies and updated existing ones in package-lock.json.
* Enhanced the document template resolution to include the new Bill of Exchange template.

## Summary

What is the background of this pull request?

## Changes

- What are the changes made in this pull request?
- Change this and that, etc...

## Issues

What are the related issues or stories?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bill-of-exchange document template with formatted dates, amounts, party details, signatures, and credential information.
  * Added signature validation and support for displaying modern W3C Data Integrity Proof credentials.
  * Registered the template for documents identified as `BILL_OF_EXCHANGE`.

* **Bug Fixes**
  * Fixed transcript sections appearing when no transcript data was available.

* **Tests**
  * Added coverage confirming eligible credentials use the correct bill-of-exchange template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->